### PR TITLE
support multiple args when adding files

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/LukasJenicek/ggit/internal/clock"
 	"github.com/LukasJenicek/ggit/internal/filesystem"
 	"github.com/LukasJenicek/ggit/internal/repository"
-	"log"
-	"os"
 )
 
 func main() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"strings"
-
 	"github.com/LukasJenicek/ggit/internal/clock"
 	"github.com/LukasJenicek/ggit/internal/filesystem"
 	"github.com/LukasJenicek/ggit/internal/repository"
+	"log"
+	"os"
 )
 
 func main() {
@@ -59,13 +57,7 @@ func main() {
 			os.Exit(0)
 		}
 
-		path := strings.TrimSpace(os.Args[2])
-		if path == "" {
-			fmt.Println("Nothing specified, nothing added.")
-			os.Exit(0)
-		}
-
-		err := repo.Add(path)
+		err := repo.Add(os.Args[2:])
 		if err != nil {
 			log.Fatalf("add: %v", err)
 		}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -6,12 +6,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/LukasJenicek/ggit/internal/ds"
 	"github.com/LukasJenicek/ggit/internal/filesystem"
 	"github.com/LukasJenicek/ggit/internal/hasher"
+	"os"
+	"path/filepath"
 )
 
 type Database struct {
@@ -88,7 +87,11 @@ func (d *Database) Store(o Object) ([]byte, error) {
 func (d *Database) SaveBlobs(files ds.Set[string]) ([]*Entry, error) {
 	entries := make([]*Entry, 0, len(files))
 
-	for _, file := range files.SortedValues() {
+	filesSorted := files.SortedValues(func(a, b string) bool {
+		return a < b
+	})
+
+	for _, file := range filesSorted {
 		entry, err := d.saveBlob(file)
 		if err != nil {
 			return nil, fmt.Errorf("save blob: %w", err)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -6,12 +6,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/LukasJenicek/ggit/internal/ds"
 	"os"
 	"path/filepath"
 
 	"github.com/LukasJenicek/ggit/internal/filesystem"
 	"github.com/LukasJenicek/ggit/internal/hasher"
-	"github.com/LukasJenicek/ggit/internal/workspace"
 )
 
 type Database struct {
@@ -85,7 +85,7 @@ func (d *Database) Store(o Object) ([]byte, error) {
 	return oid, nil
 }
 
-func (d *Database) SaveBlobs(files workspace.Set) ([]*Entry, error) {
+func (d *Database) SaveBlobs(files ds.Set[string]) ([]*Entry, error) {
 	entries := make([]*Entry, 0, len(files))
 
 	for _, file := range files.SortedValues() {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -6,10 +6,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/LukasJenicek/ggit/internal/ds"
 	"os"
 	"path/filepath"
 
+	"github.com/LukasJenicek/ggit/internal/ds"
 	"github.com/LukasJenicek/ggit/internal/filesystem"
 	"github.com/LukasJenicek/ggit/internal/hasher"
 )

--- a/internal/database/index/index.go
+++ b/internal/database/index/index.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/LukasJenicek/ggit/internal/ds"
 	"os"
 
 	"github.com/LukasJenicek/ggit/internal/database"
+	"github.com/LukasJenicek/ggit/internal/ds"
 	"github.com/LukasJenicek/ggit/internal/filesystem"
 	"github.com/LukasJenicek/ggit/internal/hasher"
 )

--- a/internal/database/index/index.go
+++ b/internal/database/index/index.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"github.com/LukasJenicek/ggit/internal/ds"
 	"os"
 
 	"github.com/LukasJenicek/ggit/internal/database"
 	"github.com/LukasJenicek/ggit/internal/filesystem"
 	"github.com/LukasJenicek/ggit/internal/hasher"
-	"github.com/LukasJenicek/ggit/internal/workspace"
 )
 
 const (
@@ -44,7 +44,7 @@ func NewIndexer(
 	}
 }
 
-func (idx *Indexer) Add(files workspace.Set) error {
+func (idx *Indexer) Add(files ds.Set[string]) error {
 	if err := idx.createIndexFile(); err != nil {
 		return fmt.Errorf("create index file: %w", err)
 	}
@@ -61,7 +61,7 @@ func (idx *Indexer) Add(files workspace.Set) error {
 	return nil
 }
 
-func (idx *Indexer) indexContent(files workspace.Set) ([]byte, error) {
+func (idx *Indexer) indexContent(files ds.Set[string]) ([]byte, error) {
 	indexContent := bytes.NewBuffer(nil)
 
 	entriesLen := files.Size()

--- a/internal/ds/ds.go
+++ b/internal/ds/ds.go
@@ -4,10 +4,21 @@ import (
 	"sort"
 )
 
+// Set
+// TODO: Implement other funcs to support interface for Set struct
+// Contains(value T) bool - to check if an element exists in the set
+// Remove(value T) - to remove an element from the set
+// Union(other Set[T]) Set[T] - to create a union of two sets
+// Intersection(other Set[T]) Set[T] - to create an intersection of two sets
 type Set[T comparable] map[T]struct{}
 
 func NewSet[T comparable](values []T) Set[T] {
 	s := Set[T]{}
+
+	if values == nil {
+		return s
+	}
+
 	for _, value := range values {
 		s.Add(value)
 	}

--- a/internal/ds/ds.go
+++ b/internal/ds/ds.go
@@ -1,7 +1,6 @@
 package ds
 
 import (
-	"fmt"
 	"sort"
 )
 
@@ -24,7 +23,7 @@ func (s Set[T]) Size() int {
 	return len(s)
 }
 
-func (s Set[T]) SortedValues() []T {
+func (s Set[T]) SortedValues(less func(a, b T) bool) []T {
 	keys := make([]T, 0, len(s))
 
 	for value := range s {
@@ -32,7 +31,7 @@ func (s Set[T]) SortedValues() []T {
 	}
 
 	sort.Slice(keys, func(i, j int) bool {
-		return fmt.Sprint(keys[i]) < fmt.Sprint(keys[j])
+		return less(keys[i], keys[j])
 	})
 
 	return keys

--- a/internal/ds/ds.go
+++ b/internal/ds/ds.go
@@ -1,1 +1,39 @@
 package ds
+
+import (
+	"fmt"
+	"sort"
+)
+
+type Set[T comparable] map[T]struct{}
+
+func NewSet[T comparable](values []T) Set[T] {
+	s := Set[T]{}
+	for _, value := range values {
+		s.Add(value)
+	}
+
+	return s
+}
+
+func (s Set[T]) Add(value T) {
+	s[value] = struct{}{}
+}
+
+func (s Set[T]) Size() int {
+	return len(s)
+}
+
+func (s Set[T]) SortedValues() []T {
+	keys := make([]T, 0, len(s))
+
+	for value := range s {
+		keys = append(keys, value)
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		return fmt.Sprint(keys[i]) < fmt.Sprint(keys[j])
+	})
+
+	return keys
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/LukasJenicek/ggit/internal/ds"
 	"os"
 	"path/filepath"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/LukasJenicek/ggit/internal/config"
 	"github.com/LukasJenicek/ggit/internal/database"
 	"github.com/LukasJenicek/ggit/internal/database/index"
+	"github.com/LukasJenicek/ggit/internal/ds"
 	"github.com/LukasJenicek/ggit/internal/filesystem"
 	"github.com/LukasJenicek/ggit/internal/workspace"
 )
@@ -119,6 +119,7 @@ func (r *Repository) Add(paths []string) error {
 
 		if path == "." {
 			files = f
+
 			break
 		}
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -38,6 +38,10 @@ func (w Workspace) ListFiles(matchPath string) ([]string, error) {
 			return filepath.SkipDir
 		}
 
+		if err != nil {
+			return err
+		}
+
 		// do not include root folder name
 		if filepath.Base(w.rootDir) == d.Name() {
 			return nil
@@ -57,7 +61,9 @@ func (w Workspace) ListFiles(matchPath string) ([]string, error) {
 			files = append(files, cleanPath)
 		}
 
-		match, err := filepath.Match(matchPath, d.Name())
+		var match bool
+
+		match, err = filepath.Match(matchPath, d.Name())
 		if err != nil {
 			return fmt.Errorf("matching path %q with pattern %q: %w", cleanPath, matchPath, err)
 		}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/LukasJenicek/ggit/internal/filesystem"
@@ -28,38 +27,7 @@ type File struct {
 	Path string
 }
 
-type Set map[string]struct{}
-
-func NewSet(values []string) Set {
-	s := Set{}
-	for _, value := range values {
-		s.Add(value)
-	}
-
-	return s
-}
-
-func (s Set) Add(value string) {
-	s[value] = struct{}{}
-}
-
-func (s Set) Size() int {
-	return len(s)
-}
-
-func (s Set) SortedValues() []string {
-	keys := make([]string, 0, len(s))
-
-	for value := range s {
-		keys = append(keys, value)
-	}
-
-	sort.Strings(keys)
-
-	return keys
-}
-
-func (w Workspace) ListFiles(matchPath string) (Set, error) {
+func (w Workspace) ListFiles(matchPath string) ([]string, error) {
 	// TODO: load more ignored files from config
 	ignore := []string{".", "..", ".git"}
 
@@ -104,5 +72,5 @@ func (w Workspace) ListFiles(matchPath string) (Set, error) {
 		return nil, fmt.Errorf("walk recursively dir %q: %w", w.rootDir, err)
 	}
 
-	return NewSet(files), nil
+	return files, nil
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/LukasJenicek/ggit/internal/ds"
 	"github.com/LukasJenicek/ggit/internal/filesystem"
 	"github.com/LukasJenicek/ggit/internal/helpers"
 	"github.com/LukasJenicek/ggit/internal/workspace"
@@ -32,11 +31,11 @@ func TestWorkspace_ListFiles(t *testing.T) {
 	assert.EqualValues(
 		t,
 		files,
-		ds.NewSet([]string{
+		[]string{
 			filepath.Join(testDataFolder, "a", "a.txt"),
 			filepath.Join(testDataFolder, "a.txt"),
 			filepath.Join(testDataFolder, "b", "b.txt"),
-		}),
+		},
 	)
 }
 
@@ -60,11 +59,11 @@ func TestWorkspace_ListSpecificFiles(t *testing.T) {
 	assert.EqualValues(
 		t,
 		files,
-		ds.NewSet([]string{
+		[]string{
 			filepath.Join(testDataFolder, "a", "a.txt"),
 			filepath.Join(testDataFolder, "a.txt"),
 			filepath.Join(testDataFolder, "b", "b.txt"),
-		}),
+		},
 	)
 }
 
@@ -88,9 +87,9 @@ func TestWorkspace_ListSpecificFile(t *testing.T) {
 	assert.EqualValues(
 		t,
 		files,
-		ds.NewSet([]string{
+		[]string{
 			filepath.Join(testDataFolder, "a", "a.txt"),
 			filepath.Join(testDataFolder, "a.txt"),
-		}),
+		},
 	)
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,6 +1,7 @@
 package workspace_test
 
 import (
+	"github.com/LukasJenicek/ggit/internal/ds"
 	"path/filepath"
 	"testing"
 
@@ -31,7 +32,7 @@ func TestWorkspace_ListFiles(t *testing.T) {
 	assert.EqualValues(
 		t,
 		files,
-		workspace.NewSet([]string{
+		ds.NewSet([]string{
 			filepath.Join(testDataFolder, "a", "a.txt"),
 			filepath.Join(testDataFolder, "a.txt"),
 			filepath.Join(testDataFolder, "b", "b.txt"),
@@ -59,7 +60,7 @@ func TestWorkspace_ListSpecificFiles(t *testing.T) {
 	assert.EqualValues(
 		t,
 		files,
-		workspace.NewSet([]string{
+		ds.NewSet([]string{
 			filepath.Join(testDataFolder, "a", "a.txt"),
 			filepath.Join(testDataFolder, "a.txt"),
 			filepath.Join(testDataFolder, "b", "b.txt"),
@@ -87,7 +88,7 @@ func TestWorkspace_ListSpecificFile(t *testing.T) {
 	assert.EqualValues(
 		t,
 		files,
-		workspace.NewSet([]string{
+		ds.NewSet([]string{
 			filepath.Join(testDataFolder, "a", "a.txt"),
 			filepath.Join(testDataFolder, "a.txt"),
 		}),

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,12 +1,12 @@
 package workspace_test
 
 import (
-	"github.com/LukasJenicek/ggit/internal/ds"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/LukasJenicek/ggit/internal/ds"
 	"github.com/LukasJenicek/ggit/internal/filesystem"
 	"github.com/LukasJenicek/ggit/internal/helpers"
 	"github.com/LukasJenicek/ggit/internal/workspace"


### PR DESCRIPTION
- support multiple args when using `ggit add` cmd. `ggit add internal/a.txt internal/b.txt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The file addition command now accepts multiple paths, enabling you to add files from several locations in one go.
  - A more flexible file collection mechanism has been introduced to enhance file management.

- **Refactor**
  - Streamlined command-line input processing by simplifying argument handling.
  - Updated file handling in the workspace to return a slice of strings instead of a custom set type.
  - Optimized file indexing and saving workflows for improved stability.

- **Tests**
  - Updated test cases to align with the new file collection and handling approaches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->